### PR TITLE
feat: 메뉴대분류 조회,등록,제거,순서수정,이름수정 API연결완료, 가게삭제,가게중복조회 API연결완료

### DIFF
--- a/src/api/restaurant.ts
+++ b/src/api/restaurant.ts
@@ -1,5 +1,10 @@
 import axiosClient from './axios'
-import { AddMenuGroups } from '../types/restaurantsAtom'
+import {
+  AddMenuGroupsType,
+  DeleteMenuGroupsType,
+  PatchMenuGroupsType,
+  PatchindexMenuGroupsType,
+} from '../types/restaurantsAtom'
 
 // 가게등록
 export const addShop = async (payload: FormData) => {
@@ -11,13 +16,50 @@ export const addShop = async (payload: FormData) => {
   }
 }
 
+//가게이름 중복체크
+export const shopNameCheck = async (payload: string) => {
+  try {
+    const response = await axiosClient.get(
+      `/api/seller-shops/shops/duplication?shopName=${payload}`,
+    )
+
+    if (response.status >= 400) {
+      throw new Error(`Server responded with status code ${response.status}`)
+    }
+
+    return response.data
+  } catch (error) {
+    console.error('에러', error)
+    throw error
+  }
+}
+
+// 가게삭제
+export const deleteShop = async (payload: number) => {
+  try {
+    const response = await axiosClient.delete(`/api/seller-shops/shops/${payload}`)
+
+    if (response.status >= 400) {
+      throw new Error(`Server responded with status code ${response.status}`)
+    }
+    return response.data
+  } catch (error) {
+    console.error('에러', error)
+    throw error
+  }
+}
+
 //내 가게들 조회
 export const getShop = async () => {
   try {
     const response = await axiosClient.get('/api/seller-shops/shops')
+    if (response.status >= 400) {
+      throw new Error(`Server responded with status code ${response.status}`)
+    }
     return response.data
   } catch (error) {
     console.error('조회 실패', error)
+    throw error
   }
 }
 
@@ -25,9 +67,13 @@ export const getShop = async () => {
 export const getShopDetail = async (payload: number | null) => {
   try {
     const response = await axiosClient.get(`/api/seller-shops/shops/${payload}`)
+    if (response.status >= 400) {
+      throw new Error(`Server responded with status code ${response.status}`)
+    }
     return response.data
   } catch (error) {
     console.error('조회 실패', error)
+    throw error
   }
 }
 
@@ -35,20 +81,83 @@ export const getShopDetail = async (payload: number | null) => {
 export const getMenuGroups = async (payload: number | null) => {
   try {
     const response = await axiosClient.get(`/api/seller-shops/menu-groups/${payload}`)
+    if (response.status >= 400) {
+      throw new Error(`Server responded with status code ${response.status}`)
+    }
     return response.data
   } catch (error) {
     console.error('조회 실패', error)
+    throw error
   }
 }
 
 //가게 대분류 등록
-export const addMenuGroups = async (payload: AddMenuGroups) => {
+export const addMenuGroups = async (payload: AddMenuGroupsType) => {
   try {
     const response = await axiosClient.post(`/api/seller-shops/menu-groups/${payload.shop_id}`, {
       menuGroupName: payload.menuGroupName,
     })
+    if (response.status >= 400) {
+      throw new Error(`Server responded with status code ${response.status}`)
+    }
     return response.data
   } catch (error) {
-    console.error('조회 실패', error)
+    console.error('실패', error)
+    throw error
+  }
+}
+
+//가게 대분류 삭제
+export const deleteMenuGroups = async (payload: DeleteMenuGroupsType) => {
+  try {
+    const response = await axiosClient.delete(
+      `/api/seller-shops/menu-groups/${payload.shop_id}?menuGroupId=${payload.menuGroupId}`,
+    )
+    if (response.status >= 400) {
+      throw new Error(`Server responded with status code ${response.status}`)
+    }
+    return response.data
+  } catch (error) {
+    console.error('실패', error)
+    throw error
+  }
+}
+
+//가게 대분류 수정
+export const patchMenuGroups = async (payload: PatchMenuGroupsType) => {
+  try {
+    const response = await axiosClient.patch(
+      `/api/seller-shops/menu-groups/${payload.shop_id}/name`,
+      {
+        menuGroupId: payload.menuGroupId,
+        menuGroupName: payload.menuGroupName,
+      },
+    )
+    if (response.status >= 400) {
+      throw new Error(`Server responded with status code ${response.status}`)
+    }
+    return response.data
+  } catch (error) {
+    console.error('실패', error)
+    throw error
+  }
+}
+
+//가게 대분류 순서 수정
+export const patchindexMenuGroups = async (payload: PatchindexMenuGroupsType) => {
+  try {
+    const response = await axiosClient.patch(`/api/seller-shops/menu-groups/${payload.shop_id}`, [
+      {
+        menuGroupId: payload.menuGroupId,
+        menuGroupSequence: payload.menuGroupSequence,
+      },
+    ])
+    if (response.status >= 400) {
+      throw new Error(`Server responded with status code ${response.status}`)
+    }
+    return response.data
+  } catch (error) {
+    console.error('실패', error)
+    throw error
   }
 }

--- a/src/components/RestaurantsManagement/MainMenuCategory/MainMenuCategory.tsx
+++ b/src/components/RestaurantsManagement/MainMenuCategory/MainMenuCategory.tsx
@@ -5,7 +5,13 @@ import { useForm } from 'react-hook-form'
 import { FormDataType } from '../../../types/user'
 import useAlert from '../../../hooks/useAlert'
 import * as S from './MainMenuCategory.style'
-import { getMenuGroups, addMenuGroups } from '../../../api/restaurant'
+import {
+  getMenuGroups,
+  addMenuGroups,
+  deleteMenuGroups,
+  patchMenuGroups,
+  patchindexMenuGroups,
+} from '../../../api/restaurant'
 import { useRecoilValue } from 'recoil'
 import { selectedShopIdState } from '../../../recoil/restaurants'
 import { useRecoilState } from 'recoil'
@@ -16,14 +22,6 @@ const MainMenuCategory: React.FC = () => {
   const [menugroup, setMenugroup] = useRecoilState(shopMenuGroups)
 
   // 카드 데이터 및 드래그/드롭 관련 상태
-  const [cards, setCards] = React.useState<(string | undefined)[]>([
-    '뼈치킨',
-    '순살치킨',
-    '특수부위',
-    '사이드메뉴',
-    '음료 & 주류',
-    '공기밥',
-  ])
   const [placeholderIndex, setPlaceholderIndex] = React.useState<number | null>(null) // placeholder의 위치를 결정
   const [dragSrcIndex, setDragSrcIndex] = React.useState<number | null>(null) // 현재 드래그 중인 카드의 인덱스
   const { register, handleSubmit, setValue, formState } = useForm<FormDataType>()
@@ -33,7 +31,6 @@ const MainMenuCategory: React.FC = () => {
   useEffect(() => {
     const getCate = async () => {
       try {
-        console.log(currentId)
         const response = await getMenuGroups(currentId)
         setMenugroup(response)
       } catch (error) {
@@ -42,8 +39,6 @@ const MainMenuCategory: React.FC = () => {
     }
     getCate()
   }, [currentId])
-
-  console.log(menugroup)
 
   // 드래그 시작 시 실행되는 함수
   const handleDragStart = (e: React.DragEvent<HTMLDivElement>, index: number) => {
@@ -66,20 +61,27 @@ const MainMenuCategory: React.FC = () => {
 
   // 드롭할 때 실행되는 함수
   const handleDrop = (e: React.DragEvent<HTMLDivElement>, dropIndex: number) => {
-    if (dragSrcIndex === null) return // dragSrcIndex가 null이면 함수 종료 (드래그된 아이템이 없음)
-
-    const draggedItem = cards[dragSrcIndex] // 드래그된 아이템을 가져옴
-    const newCards = [...cards] // 카드 배열의 복사본을 생성
-
-    // 드래그된 아이템을 배열에서 제거
-    newCards.splice(dragSrcIndex, 1)
-
-    // 드래그된 아이템이 제거된 후의 드롭 인덱스를 조정 (원래 위치보다 뒤에 드롭할 경우 인덱스가 하나 줄어듬)
+    if (dragSrcIndex === null) return
+    const draggedItem = menugroup[dragSrcIndex]
+    const newMenugroups = [...menugroup]
+    newMenugroups.splice(dragSrcIndex, 1)
     if (dragSrcIndex < dropIndex) dropIndex--
-    newCards.splice(dropIndex, 0, draggedItem) // 드롭할 위치에 드래그된 아이템을 삽입
-
-    setCards(newCards) // 카드 배열을 업데이트
-    setPlaceholderIndex(null) // 드롭 후 placeholder 인덱스를 초기화
+    newMenugroups.splice(dropIndex, 0, draggedItem)
+    setMenugroup(newMenugroups)
+    setPlaceholderIndex(null)
+    console.log(dropIndex)
+    console.log(draggedItem.menuGroupId)
+    patchindexMenuGroups({
+      shop_id: currentId,
+      menuGroupSequence: dropIndex,
+      menuGroupId: draggedItem.menuGroupId,
+    })
+      .then(() => {
+        toast('카테고리 순서변경이 반영되었습니다.', 2000, 'success')
+      })
+      .catch(() => {
+        toast('카테고리 순서변경에 실패하였습니다.', 2000, 'error')
+      })
   }
 
   // 드래그 아이템이 다른 아이템 위에 올라갔을 때의 이벤트 핸들러
@@ -94,35 +96,52 @@ const MainMenuCategory: React.FC = () => {
   }
 
   // 카테고리 제출 핸들러
-  const onCategorySubmit = async (data: FormDataType) => {
-    setCards((prev) => [...prev, data.menuCategory]) // 이전 카드 목록에 새 카테고리 추가
-    setValue('menuCategory', '') // 'menuCategory' 입력 필드의 값을 리셋
-    console.log(data)
-    try {
-      const response = await addMenuGroups({ shop_id: currentId, menuGroupName: data.menuCategory })
-      console.log(response)
-    } catch (error) {
-      console.log(error)
-    }
+  const onCategorySubmit = (data: FormDataType) => {
+    setValue('menuCategory', '')
+    addMenuGroups({ shop_id: currentId, menuGroupName: data.menuCategory })
+      .then(async () => {
+        const reload = await getMenuGroups(currentId)
+        setMenugroup(reload)
+        toast('메뉴카테고리가 정상적으로 추가되었습니다', 2000, 'success')
+      })
+      .catch(() => {
+        toast('메뉴카테고리가 등록에 실패했습니다', 2000, 'error')
+      })
   }
 
   // 카테고리 입력 변경 핸들러
   const handleCategoryInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    e.target.value = e.target.value.replace(/[^a-zA-Z가-힣ㄱ-ㅎ\s]/g, '') // 입력값에서 특정 문자를 제외한 모든 문자를 제거 (영문자, 한글, 공백만 허용)
+    e.target.value = e.target.value.replace(/[^a-zA-Z가-힣ㄱ-ㅎ\s]/g, '')
   }
 
   // 수정 핸들러
-  const handleEdit = (index: number) => {
-    const newContent = prompt('새로운 이름을 입력하세요', cards[index]) // 사용자에게 새로운 이름 입력을 요청 (기본값으로 현재 카드의 내용을 제공)
-    if (newContent !== null && newContent !== undefined) {
-      // 새로운 내용이 null이나 undefined가 아니라면
-      setCards((prev) => prev.map((content, i) => (i === index ? newContent : content))) // 해당 인덱스의 카드 내용을 업데이트
+  const handleEdit = (menuGroupId: number) => {
+    const newName = prompt('수정할 카테고리명을 입력해주세요.')
+    if (newName !== null) {
+      patchMenuGroups({ shop_id: currentId, menuGroupId: menuGroupId, menuGroupName: newName })
+        .then(async () => {
+          const reload = await getMenuGroups(currentId)
+          setMenugroup(reload)
+          toast('메뉴카테고리가 정상적으로 수정되었습니다', 2000, 'success')
+        })
+        .catch(() => {
+          toast('메뉴카테고리 수정에 실패했습니다.', 2000, 'error')
+        })
     }
   }
 
   // 삭제 핸들러
-  const handleDelete = (index: number) => {
-    setCards((prev) => prev.filter((_, i) => i !== index)) // 해당 인덱스의 카드를 제외한 모든 카드를 유지
+  const handleDelete = (menuGroupId: number) => {
+    deleteMenuGroups({ shop_id: currentId, menuGroupId: menuGroupId })
+      .then(async () => {
+        const reload = await getMenuGroups(currentId)
+        setMenugroup(reload)
+        toast('메뉴카테고리가 정상적으로 삭제되었습니다', 2000, 'success')
+      })
+      .catch((error) => {
+        toast('메뉴카테고리 삭제에 실패했습니다.', 2000, 'error')
+        console.error(error)
+      })
   }
 
   useEffect(() => {
@@ -153,8 +172,8 @@ const MainMenuCategory: React.FC = () => {
       <S.Categorylist>
         {
           // 반복문을 사용해 cards 배열의 각 아이템을 렌더링
-          cards.map((content, index) => (
-            <React.Fragment key={index}>
+          menugroup.map((content, index) => (
+            <React.Fragment key={content.menuGroupId}>
               {
                 // 만약 현재 인덱스가 placeholderIndex와 같다면 Placeholder 컴포넌트를 렌더링
                 index === placeholderIndex && (
@@ -168,12 +187,12 @@ const MainMenuCategory: React.FC = () => {
               <S.StyledItemContainer
                 onDragOver={
                   // 만약 현재 인덱스가 마지막 아이템의 인덱스라면, 드래그 오버 이벤트를 핸들링
-                  index === cards.length - 1
+                  index === menugroup.length - 1
                     ? (e) => {
                         e.preventDefault()
                         // 만약 placeholderIndex가 마지막 위치가 아니라면, 이를 마지막 위치로 설정
-                        if (placeholderIndex !== cards.length) {
-                          setPlaceholderIndex(cards.length)
+                        if (placeholderIndex !== menugroup.length) {
+                          setPlaceholderIndex(menugroup.length)
                         }
                       }
                     : undefined
@@ -187,18 +206,22 @@ const MainMenuCategory: React.FC = () => {
                       onDragEnter={(e) => handleDragEnter(e, index)} // 드래그 엔터 이벤트 핸들러
                       onDrop={(e) => {
                         // 드롭 이벤트 핸들러. 만약 placeholderIndex가 마지막 위치라면, 드롭 이벤트를 처리
-                        if (placeholderIndex === cards.length) {
-                          handleDrop(e, cards.length)
+                        if (placeholderIndex === menugroup.length) {
+                          handleDrop(e, menugroup.length)
                         }
                       }}
                       onDragEnd={handleDragEnd} // 드래그 종료 이벤트 핸들러
                     >
-                      <div style={{ flexGrow: 1 }}>{content}</div>
+                      <div style={{ flexGrow: 1 }}>{content.menuGroupName}</div>
                     </S.StyleCard>
                   </Grid>
                   <S.StyleGrid item xs={6}>
-                    <S.StyleitemBtn onClick={() => handleEdit(index)}>수정</S.StyleitemBtn>
-                    <S.StyleitemBtn onClick={() => handleDelete(index)}>삭제</S.StyleitemBtn>
+                    <S.StyleitemBtn onClick={() => handleEdit(content.menuGroupId)}>
+                      수정
+                    </S.StyleitemBtn>
+                    <S.StyleitemBtn onClick={() => handleDelete(content.menuGroupId)}>
+                      삭제
+                    </S.StyleitemBtn>
                   </S.StyleGrid>
                 </Grid>
               </S.StyledItemContainer>
@@ -207,7 +230,7 @@ const MainMenuCategory: React.FC = () => {
         }
         {
           // 만약 placeholderIndex가 마지막 위치라면, 마지막 위치에 Placeholder 컴포넌트를 추가
-          placeholderIndex === cards.length && (
+          placeholderIndex === menugroup.length && (
             <S.Placeholder
               onDragOver={handleDragOver}
               onDrop={(e) => handleDrop(e, placeholderIndex)}

--- a/src/components/RestaurantsManagement/RestaurantDeleteModal/RestaurantDeleteModal.style.ts
+++ b/src/components/RestaurantsManagement/RestaurantDeleteModal/RestaurantDeleteModal.style.ts
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled'
+
+export const StyledBox = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 500px;
+  height: 200px;
+  background-color: #fff;
+  border: 2px solid #000;
+  box-shadow: 4px 4px 0 0 rgba(0, 0, 0, 0.2);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`
+export const ButtonBox = styled.div`
+  margin-top: 30px;
+  display: flex;
+  gap: 50px;
+  button {
+    font-size: 18px;
+  }
+`

--- a/src/components/RestaurantsManagement/RestaurantDeleteModal/RestaurantDeleteModal.tsx
+++ b/src/components/RestaurantsManagement/RestaurantDeleteModal/RestaurantDeleteModal.tsx
@@ -1,0 +1,66 @@
+import Button from '@mui/material/Button'
+import Typography from '@mui/material/Typography'
+import Modal from '@mui/material/Modal'
+import { useRecoilValue, useRecoilState } from 'recoil'
+import {
+  selectedShopNameState,
+  shopdeletemodal,
+  selectedShopIdState,
+} from '../../../recoil/restaurants'
+import * as S from './RestaurantDeleteModal.style'
+import { deleteShop } from '../../../api/restaurant'
+import useAlert from '../../../hooks/useAlert'
+
+const RestaurantDeleteModal = () => {
+  const [open, setOpen] = useRecoilState(shopdeletemodal)
+  const ShopName = useRecoilValue(selectedShopNameState)
+  const ShopId = useRecoilValue(selectedShopIdState)
+  const toast = useAlert()
+
+  const handleClose = () => setOpen(false)
+
+  const handleDelete = () => {
+    if (ShopId !== null) {
+      deleteShop(ShopId)
+        .then(() => {
+          toast('현재가게를 삭제하였습니다.', 2000, 'success')
+          setTimeout(() => {
+            setOpen(false)
+            window.location.reload()
+          }, 2000)
+        })
+        .catch(() => {
+          toast('삭제에 실패하였습니다', 2000, 'error')
+        })
+    }
+  }
+
+  console.log(ShopId)
+
+  return (
+    <div>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
+      >
+        <S.StyledBox>
+          <Typography id="modal-modal-title" variant="h6" component="h2">
+            정말로 {ShopName} 를(을) 삭제할까요?
+          </Typography>
+          <S.ButtonBox>
+            <Button variant="contained" onClick={handleDelete}>
+              삭제하기
+            </Button>
+            <Button variant="contained" onClick={handleClose}>
+              취소
+            </Button>
+          </S.ButtonBox>
+        </S.StyledBox>
+      </Modal>
+    </div>
+  )
+}
+
+export default RestaurantDeleteModal

--- a/src/components/RestaurantsManagement/RestaurantsProfile/RestaurantsProfile.tsx
+++ b/src/components/RestaurantsManagement/RestaurantsProfile/RestaurantsProfile.tsx
@@ -2,10 +2,11 @@ import { Typography, Card, CardContent, CardMedia, Grid } from '@mui/material'
 import React, { useEffect } from 'react'
 import * as S from './RestaurantsProfile.style'
 import { getShopDetail } from '../../../api/restaurant'
-import { useRecoilValue } from 'recoil'
+import { useRecoilValue, useSetRecoilState } from 'recoil'
 import { selectedShopIdState } from '../../../recoil/restaurants'
-import { shopDetailState } from '../../../recoil/restaurants'
+import { shopDetailState, shopdeletemodal } from '../../../recoil/restaurants'
 import { useRecoilState } from 'recoil'
+import RestaurantDeleteModal from '../RestaurantDeleteModal/RestaurantDeleteModal'
 
 interface ProfileProps {
   setMenupage: (value: number) => void
@@ -14,6 +15,7 @@ interface ProfileProps {
 const RestaurantsProfile: React.FC<ProfileProps> = ({ setMenupage }) => {
   const currentId = useRecoilValue(selectedShopIdState)
   const [shop, setShop] = useRecoilState(shopDetailState)
+  const ModalOpen = useSetRecoilState(shopdeletemodal)
 
   useEffect(() => {
     const getDatil = async () => {
@@ -38,6 +40,11 @@ const RestaurantsProfile: React.FC<ProfileProps> = ({ setMenupage }) => {
   return (
     <S.Wrapper>
       <S.ProfileBtnWrapper>
+        {currentId && (
+          <S.StyledButton variant="outlined" onClick={() => ModalOpen(true)}>
+            가게 삭제하기
+          </S.StyledButton>
+        )}
         <S.StyledButton variant="outlined" onClick={() => setMenupage(6)}>
           가게 정보수정
         </S.StyledButton>
@@ -121,6 +128,7 @@ const RestaurantsProfile: React.FC<ProfileProps> = ({ setMenupage }) => {
               </Grid>
             </CardContent>
           </S.StyledCard>
+          <RestaurantDeleteModal />
         </S.ProfileWrapper>
       ) : (
         <S.ProfileWrapper>

--- a/src/recoil/restaurants.ts
+++ b/src/recoil/restaurants.ts
@@ -47,3 +47,9 @@ export const shopMenuGroups = atom<MenuGroupsType[]>({
   key: 'shopMenuGroups',
   default: [],
 })
+
+//가게 메뉴 대분류
+export const shopdeletemodal = atom({
+  key: 'shopdeletemodal',
+  default: false,
+})

--- a/src/types/restaurantsAtom.ts
+++ b/src/types/restaurantsAtom.ts
@@ -8,7 +8,24 @@ export interface MenuGroupsType {
   menuGroupName: string
 }
 
-export interface AddMenuGroups {
+export interface AddMenuGroupsType {
   shop_id: number | null
   menuGroupName?: string
+}
+
+export interface DeleteMenuGroupsType {
+  shop_id: number | null
+  menuGroupId?: number
+}
+
+export interface PatchMenuGroupsType {
+  shop_id: number | null
+  menuGroupId?: number
+  menuGroupName?: string
+}
+
+export interface PatchindexMenuGroupsType {
+  shop_id: number | null
+  menuGroupId: number
+  menuGroupSequence: number
 }


### PR DESCRIPTION
![image](https://github.com/Han-Yip-Man/Han-Yip-Man-front/assets/97070078/3954f1e6-5d68-41fa-a04b-fc163903030e)
1. 메뉴 대분류 관리 컴포넌트에서 등록, 삭제, 이름수정, 드래그앤드롭(순서변경) API작업하고, 테스트까지 완료했습니다.
<br>

![image](https://github.com/Han-Yip-Man/Han-Yip-Man-front/assets/97070078/65a092c3-28bc-4014-bfd9-84a3f2fb70ae)

2.가게관리 기본페이지에서 가게 삭제하기 버튼 추가하였습니다. 모달을 통해 한번 더 확인합니다.
<br>
![image](https://github.com/Han-Yip-Man/Han-Yip-Man-front/assets/97070078/6122b8da-b858-4741-a3e4-aa2db5b33f62)

3. 가게등록에서 중복체크 기능 추가하였습니다. 중복체크를 하지 않거나, 중복체크를 한후에 상호명을 바꾸면 가게등록을 할수 없습니다.